### PR TITLE
options to add / rm misc proceseses, ~readme, minor refactorings

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,12 +156,8 @@ Requires 1 person in order to join at first but if they leave, the seeding accou
 Solution: A process is not running that is required for the application to determine if the game server is ready to be joined
 - One of these could be your Steam Overlay. If it is disabled in your setttings, you can remove it from the list of processes in `seeding.yaml`. Example:
 ```
-processes:
-  # list of procs to checkwhen determining if the game is running - see 'is_fully_running()' in 'seeding.py'
-  # + add more if you have other procs that need to be running for the game to be fully running
-  # - remove any that are not needed or are causing false negatives for 'is_fully_running()'
-  game_processes:
-    - "GameOverlayUI.exe" # Remove this one if your Steam Overlay is disabled
-    - "HLL_BugReportUploader.exe"
-    - "CrashReportClient.exe"
+misc_game_processes:
+  - "GameOverlayUI.exe" # Remove/comment this one if your Steam Overlay is disabled
+  - "HLL_BugReportUploader.exe"
+  - "CrashReportClient.exe"
 ```

--- a/README.md
+++ b/README.md
@@ -150,3 +150,18 @@ instances.
 Note: `min_players` value of 1 is nearly the same as 0 since the player count will be including yourself.
 Requires 1 person in order to join at first but if they leave, the seeding account will not move on.
 
+## Troubleshooting
+
+### The game starts, but the script never joines a game, it's just stuck on Launching Game
+Solution: A process is not running that is required for the application to determine if the game server is ready to be joined
+- One of these could be your Steam Overlay. If it is disabled in your setttings, you can remove it from the list of processes in `seeding.yaml`. Example:
+```
+processes:
+  # list of procs to checkwhen determining if the game is running - see 'is_fully_running()' in 'seeding.py'
+  # + add more if you have other procs that need to be running for the game to be fully running
+  # - remove any that are not needed or are causing false negatives for 'is_fully_running()'
+  game_processes:
+    - "GameOverlayUI.exe" # Remove this one if your Steam Overlay is disabled
+    - "HLL_BugReportUploader.exe"
+    - "CrashReportClient.exe"
+```

--- a/hll_game.py
+++ b/hll_game.py
@@ -1,4 +1,5 @@
 import subprocess, time
+import yaml
 from steam import game_servers as gs
 
 # steam processes
@@ -10,6 +11,10 @@ launch_exe = 'HLL_Launch.exe'
 # The game itself
 hll_exe = 'HLL-Win64-Shipping.exe'
 # Last couple processes running after game exit
+with open('seeding.yaml', 'r') as seeding_cfg_file:
+    seeding_cfg = yaml.safe_load(seeding_cfg_file)
+    misc_processes = seeding_cfg['processes']['game_processes']
+
 bugreport_exe = 'HLL_BugReportUploader.exe'
 overlay_exe = 'GameOverlayUI.exe'
 crash_window_exe = 'CrashReportClient.exe'
@@ -58,16 +63,17 @@ def did_game_crash():
 def is_running():
     return __process_exists(hll_exe)
 
-
 def is_fully_running():
-    return (is_running() and __process_exists(bugreport_exe)
-            and __process_exists(overlay_exe) and __process_exists(crash_window_exe))
-
+    for process_name in misc_processes:
+        if not __process_exists(process_name):
+            return False
+    return is_running()
 
 def is_fully_dead():
-    return not (is_running() or __process_exists(bugreport_exe)
-                or __process_exists(overlay_exe) or __process_exists(crash_window_exe))
-
+    for process_name in misc_processes:
+        if __process_exists(process_name):
+            return False
+    return not is_running()
 
 def kill():
     if is_running():

--- a/hll_game.py
+++ b/hll_game.py
@@ -11,9 +11,12 @@ launch_exe = 'HLL_Launch.exe'
 # The game itself
 hll_exe = 'HLL-Win64-Shipping.exe'
 # Last couple processes running after game exit
-with open('seeding.yaml', 'r') as seeding_cfg_file:
-    seeding_cfg = yaml.safe_load(seeding_cfg_file)
-    misc_processes = seeding_cfg['processes']['game_processes']
+try:
+    with open('seeding.yaml', 'r') as seeding_cfg_file:
+        seeding_cfg = yaml.safe_load(seeding_cfg_file)
+        misc_processes = seeding_cfg['misc_game_processes']
+except Exception as err:
+    print(f"Error loading seeding.yaml: {err}")
 
 bugreport_exe = 'HLL_BugReportUploader.exe'
 overlay_exe = 'GameOverlayUI.exe'
@@ -86,7 +89,7 @@ def kill_crash_window():
 
 
 def kill_all():
-    for process_name in [hll_exe, crash_window_exe, bugreport_exe, overlay_exe]:
+    for process_name in misc_processes.append(hll_exe):
         if __process_exists(process_name):
             __process_kill(process_name)
 

--- a/seeding.yaml
+++ b/seeding.yaml
@@ -67,7 +67,7 @@ server_query_timeout: 15
 query_timeout_limit: 6
 # Check if name is in the player list
 check_idle_kick: false
-player_name: SodiumEnglish
+player_name: SodiumEnglish # replace this with your in-game name - use quotes if contains special characters
 
 
 # When out of servers, search the steam server list for more seeding servers
@@ -90,6 +90,14 @@ perpetual_mode:
     fr only, french # will be banned unless you are actually french (they check steam profile country)
   ]
 
+processes:
+  # list of procs to checkwhen determining if the game is running - see 'is_fully_running()' in 'seeding.py'
+  # + add more if you have other procs that need to be running for the game to be fully running
+  # - remove any that are not needed or are causing false negatives for 'is_fully_running()'
+  game_processes:
+    - "GameOverlayUI.exe" # Remove/comment this one if your Steam Overlay is disabled
+    - "HLL_BugReportUploader.exe"
+    - "CrashReportClient.exe"
 
 # options that help with script development/debugging
 debug:

--- a/seeding.yaml
+++ b/seeding.yaml
@@ -90,14 +90,13 @@ perpetual_mode:
     fr only, french # will be banned unless you are actually french (they check steam profile country)
   ]
 
-processes:
-  # list of procs to checkwhen determining if the game is running - see 'is_fully_running()' in 'seeding.py'
-  # + add more if you have other procs that need to be running for the game to be fully running
-  # - remove any that are not needed or are causing false negatives for 'is_fully_running()'
-  game_processes:
-    - "GameOverlayUI.exe" # Remove/comment this one if your Steam Overlay is disabled
-    - "HLL_BugReportUploader.exe"
-    - "CrashReportClient.exe"
+# list of procs to checkwhen determining if the game is running - see 'is_fully_running()' in 'seeding.py'
+# + add more if you have other procs that need to be running for the game to be fully running
+# - remove any that are not needed or are causing false negatives for 'is_fully_running()'
+misc_game_processes:
+  - "GameOverlayUI.exe" # Remove/comment this one if your Steam Overlay is disabled
+  - "HLL_BugReportUploader.exe"
+  - "CrashReportClient.exe"
 
 # options that help with script development/debugging
 debug:


### PR DESCRIPTION
## Why this PR?
I ran into issue where the fact that I had disabled my Steam Overlay (aka `GameOverlayUI.exe`) was preventing the server search & join from occurring. Also Matt is awesome and this is awesome, so I wanted to contribute 😉 

## What it do?
- Adds a `processes.game_processes` data struct in `seeding.yaml` to facilitate add/rm of game processes you might want to be running
- refactors a couple of functions

## Did you test it?
- Yes I did. I did not write unit tests, but I manually tested it with the steam overlay process added/commented-out in the `seeding.yaml` config file.